### PR TITLE
Fix for Rumeme::SmsInterface#send_messages on 1.9.3

### DIFF
--- a/lib/rumeme/sms_interface.rb
+++ b/lib/rumeme/sms_interface.rb
@@ -174,7 +174,9 @@ module Rumeme
 
       path = '/'
 
-      resp, data = http_connection.post(path, text_buffer, headers)
+      resp = http_connection.post(path, text_buffer, headers)
+      data = resp.body
+      
       p resp.inspect
       p data.inspect
 


### PR DESCRIPTION
Looks like version 1.1 support for Net::Http#post was removed in 1.9.3
